### PR TITLE
rename "vlang" to "v".

### DIFF
--- a/ftdetect/ftdetect.vim
+++ b/ftdetect/ftdetect.vim
@@ -1,3 +1,3 @@
-au BufNewFile,BufRead *.v   set filetype=vlang syntax=vlang
-au BufNewFile,BufRead *.vv  set filetype=vlang syntax=vlang
-au BufNewFile,BufRead *.vsh set filetype=vlang syntax=vlang
+au BufNewFile,BufRead *.v   set filetype=v syntax=v
+au BufNewFile,BufRead *.vv  set filetype=v syntax=v
+au BufNewFile,BufRead *.vsh set filetype=v syntax=v

--- a/indent/indent.vim
+++ b/indent/indent.vim
@@ -1,7 +1,7 @@
 if exists("b:current_indent")
 	finish
 endif
-let b:current_indent="vlang"
+let b:current_indent="v"
 
 setlocal autoindent smartindent
 setlocal indentkeys+=0=},0=) indentexpr=VIndentExpr(v:lnum)

--- a/syntax/v.vim
+++ b/syntax/v.vim
@@ -19,7 +19,7 @@
 if exists("b:current_syntax")
 	finish
 endif
-let b:current_syntax="vlang"
+let b:current_syntax="v"
 
 " ==============================================================================
 " Blocks


### PR DESCRIPTION
Because https://github.com/vlang/v/wiki/FAQ/5490806830b96584df65e9d7a19444c020a0f759 says the name of the language is "V", not "vlang".